### PR TITLE
Fix whitespaces of a string value skipped while reading a string started with unicode

### DIFF
--- a/src/main/java/de/maxhenkel/configbuilder/CommentedProperties.java
+++ b/src/main/java/de/maxhenkel/configbuilder/CommentedProperties.java
@@ -164,6 +164,7 @@ public class CommentedProperties implements Map<String, String> {
         StringBuilder value = new StringBuilder();
         StringReader reader = new StringReader(line);
 
+        boolean hasBackslashAppeared = false;
         boolean isKey = true;
         boolean isComment = false;
         boolean isPrecedingBackslash = false;
@@ -192,6 +193,7 @@ public class CommentedProperties implements Map<String, String> {
             }
             if (c == '\\') {
                 isPrecedingBackslash = true;
+                hasBackslashAppeared = true;
                 continue;
             }
             if (c == '#' || c == '!') {
@@ -217,7 +219,7 @@ public class CommentedProperties implements Map<String, String> {
                 }
                 key.append((char) c);
             } else {
-                if (isStartOfValue) {
+                if (isStartOfValue && !hasBackslashAppeared) {
                     if (isWhitespace(c) || isSeparator(c)) {
                         continue;
                     }


### PR DESCRIPTION
[simple voice chat](https://github.com/henkelmax/simple-voice-chat),  Minecraft mod that is broadly used by Minecraft users, has a bug that if one selects an microphone which name is comprised of unicodes and saves it to the config, its name is broken after reloading config(rebooting Minecraft client).
For example,  let one's microphone name be \uBA38\uB9AC\uC5D0 \uAC70\uB294 \uC218\uD654\uAE30. When a user selects it, the mod saves its name to the config and 
```
microphone=\uBA38\uB9AC\uC5D0 \uAC70\uB294 \uC218\uD654\uAE30
```
saved.
After he reboots his Minecraft, the mod tries to read it, all whitespaces between unicodes are removed and
```
microphone=\uBA38\uB9AC\uC5D0\uAC70\uB294\uC218\uD654\uAE30
``` 
is written to the config file, causing his Minecraft mod to lose his microphone name.
 The main cause is located at  `CommentedProperties#readLine` method, which reads line and parses it to key and value pair. It has a local variable named `boolean isStartOfValue` to skip meaningless whitespace or separator character shown up right after a key and a separator is fully read and it's ready to read a value. 
```java
         if (isStartOfValue) {
                    if (isWhitespace(c) || isSeparator(c)) {
                        continue;
                    }
                }
                value.append((char) c);
                isStartOfValue = false;
         }
```
It does not matter only if the value starts with non-unicode characters. But when it comes to reading first unicode of the value, it cannot reach to the codes(see above), trapped at 
```java
            if (isPrecedingBackslash) {
                if (isKey) {
                    key.append((char) readEscapedCharacter(c, reader));
                } else {
                    value.append((char) readEscapedCharacter(c, reader));
                }
                isPrecedingBackslash = false;
                continue;
            }
            if (c == '\\') {
                isPrecedingBackslash = true;
                continue;
            }
```

In order to solve this issue, it might be the best solution that adds just one flag variable to notify the reader that it should skip whitespace or separator only when the reader haven't met a backslash character(which means the value does not start with unicode characters). For more detail, please check the commits.
